### PR TITLE
Implement close method

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -56,6 +56,7 @@ export class WebSocketServer extends EventEmitter {
     constructor(configs: ServerConfigs, callback?: Listener);
     broadcast(message: string | Buffer, options: BroadcastOptions): void;
     startAutoPing(interval: number, appLevel?: boolean, terminateOnMiss?: boolean): void;
+    close(callback?: Listener): void;
 }
 
 export const native: any;

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,9 +45,9 @@ native.client.group.onConnection(clientGroup, e => {
             stack: "uWs client connection error"
         });
     });
-}), native.client.group.onDisconnection(clientGroup, (e, t, r, n) => {
-    n.external = null, process.nextTick(() => {
-        n.emit("close", t, r), n = null;
+}), native.client.group.onDisconnection(clientGroup, (e, t, r, s) => {
+    s.external = null, process.nextTick(() => {
+        s.emit("close", t, r), s = null;
     }), native.clearUserData(e);
 });
 
@@ -73,8 +73,8 @@ class WebSocket extends EventEmitter {
     }
     send(e, t, r) {
         if (!this.external) return r && r(new Error("Not opened"));
-        const n = t && t.binary || "string" != typeof e ? OPCODE_BINARY : OPCODE_TEXT;
-        native[this.executeOn].send(this.external, e, n, r ? () => process.nextTick(r) : null, t && t.compress);
+        const s = t && t.binary || "string" != typeof e ? OPCODE_BINARY : OPCODE_TEXT;
+        native[this.executeOn].send(this.external, e, s, r ? () => process.nextTick(r) : null, t && t.compress);
     }
     terminate() {
         this.external && (native[this.executeOn].terminate(this.external), this.external = null);
@@ -88,9 +88,9 @@ native.setNoop(noop);
 
 class WebSocketServer extends EventEmitter {
     constructor(e, t) {
-        super(), this.isAppLevelPing = !1, this.lastUpgradeListener = !0, this.noDelay = !!e.noDelay, 
-        e.path && "/" !== e.path[0] && (e.path = `/${e.path}`), this.configureNative(e), 
-        this.configureServer(e), this.start(e, t);
+        super(), this.isAppLevelPing = !1, this.lastUpgradeListener = !0, this.passedServer = !1, 
+        this.noDelay = !!e.noDelay, this.passedServer = !!e.server, e.path && "/" !== e.path[0] && (e.path = `/${e.path}`), 
+        this.configureNative(e), this.configureServer(e), this.start(e, t);
     }
     broadcast(e, t) {
         this.serverGroup && native.server.group.broadcast(this.serverGroup, e, t && t.binary || !1);
@@ -101,26 +101,37 @@ class WebSocketServer extends EventEmitter {
             t ? e.send(APP_PING_CODE) : e.ping())), this.startAutoPing(e, t, r);
         }, e);
     }
+    close(e) {
+        this.httpServer && (this.errorListener && this.httpServer.removeListener("error", this.errorListener), 
+        this.newListenerListener && this.httpServer.removeListener("newListener", this.newListenerListener), 
+        this.upgradeListener && this.httpServer.removeListener("upgrade", this.upgradeListener), 
+        this.passedServer ? this.closeContinuation(e) : this.httpServer.close(() => this.closeContinuation(e)));
+    }
+    closeContinuation(e) {
+        this.serverGroup && (native.server.group.close(this.serverGroup), this.serverGroup = null), 
+        this.emit("close"), e && e();
+    }
     start(e, t) {
         e.port && this.httpServer.listen(e.port, e.host || null, () => {
             this.emit("listening"), t && t();
         });
     }
     configureServer(e) {
-        this.httpServer = e.server || HTTP.createServer((e, t) => t.end()), this.httpServer.on("error", e => this.emit("error", e)), 
-        this.httpServer.on("newListener", (e, t) => "upgrade" === e ? this.lastUpgradeListener = !1 : null), 
-        this.httpServer.on("upgrade", (t, r) => {
+        this.httpServer = e.server || HTTP.createServer((e, t) => t.end()), this.httpServer.on("error", this.errorListener = (e => this.emit("error", e))), 
+        this.httpServer.on("newListener", this.newListenerListener = ((e, t) => {
+            "upgrade" === e && (this.lastUpgradeListener = !1);
+        })), this.httpServer.on("upgrade", this.upgradeListener = ((t, r) => {
             if (e.path && e.path !== t.url.split("?")[0].split("#")[0]) return this.lastUpgradeListener ? this.dropConnection(r, 400, "URL not supported") : null;
             if (e.verifyClient) {
-                const n = {
+                const s = {
                     req: t,
                     headers: t.headers,
                     secure: !(!t.connection.authorized && !t.connection.encrypted)
                 };
-                return e.verifyClient(n, (e, n, s) => e ? this.handleUpgrade(t, r) : this.dropConnection(r, n, s));
+                return e.verifyClient(s, (e, s, n) => e ? this.handleUpgrade(t, r) : this.dropConnection(r, s, n));
             }
             return this.handleUpgrade(t, r);
-        });
+        }));
     }
     configureNative(e) {
         let t = 0;
@@ -132,9 +143,9 @@ class WebSocketServer extends EventEmitter {
         }), native.server.group.onMessage(this.serverGroup, (e, t) => {
             if (this.isAppLevelPing && "string" != typeof e && (e = Buffer.from(e))[0] === APP_PONG_CODE && 1 === e.length) return t.emit("pong");
             t.emit("message", e);
-        }), native.server.group.onDisconnection(this.serverGroup, (e, t, r, n) => {
-            n.external = null, process.nextTick(() => {
-                n.emit("close", t, r), n = null;
+        }), native.server.group.onDisconnection(this.serverGroup, (e, t, r, s) => {
+            s.external = null, process.nextTick(() => {
+                s.emit("close", t, r), s = null;
             }), native.clearUserData(e);
         }), native.server.group.onPing(this.serverGroup, (e, t) => t.emit("ping", e)), native.server.group.onPong(this.serverGroup, (e, t) => t.emit("pong", e));
     }
@@ -142,11 +153,11 @@ class WebSocketServer extends EventEmitter {
         return e.end(`HTTP/1.1 ${t} ${r}\r\n\r\n`);
     }
     handleUpgrade(e, t) {
-        const r = e.headers["sec-websocket-key"], n = t.ssl ? t.ssl._external : null, s = t.ssl ? t._parent._handle : t._handle;
-        if (s && r && 24 === r.length) {
+        const r = e.headers["sec-websocket-key"], s = t.ssl ? t.ssl._external : null, n = t.ssl ? t._parent._handle : t._handle;
+        if (n && r && 24 === r.length) {
             t.setNoDelay(this.noDelay);
-            const i = native.transfer(-1 === s.fd ? s : s.fd, n);
-            t.on("close", (t, n) => {
+            const i = native.transfer(-1 === n.fd ? n : n.fd, s);
+            t.on("close", (t, s) => {
                 this.serverGroup && (this.upgradeReq = e, native.upgrade(this.serverGroup, i, r, e.headers["sec-websocket-extensions"], e.headers["sec-websocket-protocol"]));
             });
         }


### PR DESCRIPTION
This PR adds the close method to the WebSocketServer class. It is a method found in the uws module but left out of the ClusterWS-uWS.  I modeled my solution after the uws version.

The close method is useful for clean shutdowns but also for unit tests where you may be creating and destroying many WebSocketServers.